### PR TITLE
Print the error code with the status code

### DIFF
--- a/witSpeech.js
+++ b/witSpeech.js
@@ -47,7 +47,7 @@ const extractSpeechIntent = function (access_token, stream, content_type, option
     // Pipe the request
     stream.pipe(request(request_options, function (error, response, body) {
         if (response && response.statusCode != 200) {
-            error = "Invalid response received from server: " + response.statusCode
+            error = "Invalid response received from server: " + response.statusCode + (body.code ? ' - code: ' + body.code : '')
         }
         callback(error, body);
     }));


### PR DESCRIPTION
As per the [API docs](https://wit.ai/docs/http/20170307#post__speech_link) the 400 status code could be caused by any number of issues. Printing the error code with the status code helps to identify the source of the issue.